### PR TITLE
fix(#3518018): only flush textimage style when path is null

### DIFF
--- a/src/Hook/TextimageHooks.php
+++ b/src/Hook/TextimageHooks.php
@@ -138,8 +138,10 @@ class TextimageHooks {
    */
   #[Hook('image_style_flush')]
   public function imageStyleFlush(ImageStyleInterface $style, ?string $path = NULL): void {
-    // Manage the textimage part of image style flushing.
-    \Drupal::service(TextimageFactoryInterface::class)->flushStyle($style);
+    if (is_null($path)) {
+      // Manage the textimage part of image style flushing.
+      \Drupal::service(TextimageFactoryInterface::class)->flushStyle($style);
+    }
   }
 
   /**

--- a/tests/src/Kernel/TextimageApiTest.php
+++ b/tests/src/Kernel/TextimageApiTest.php
@@ -425,4 +425,30 @@ class TextimageApiTest extends KernelTestBase {
     $textimage->setTargetUri('public://textimage-testing/bingo' . chr(1) . '.png');
   }
 
+  /**
+   * Test that a style flush for a single path keeps textimage files.
+   *
+   * @see https://www.drupal.org/i/3518018
+   */
+  public function testStyleFlushWithPath(): void {
+    $style = ImageStyle::load('textimage_test');
+
+    // Build a textimage so a cached image file exists in the store.
+    $this->textimageFactory->get()
+      ->setStyle($style)
+      ->process('bingo')
+      ->buildImage();
+    $directory = $this->textimageFactory->getStoreUri('/cache/styles/') . $style->id();
+    $this->assertDirectoryExists($directory);
+
+    // Flush the style for one source file. This happens when core deletes
+    // a file entity. The textimage store must be kept.
+    $style->flush('public://unrelated-file.png');
+    $this->assertDirectoryExists($directory);
+
+    // Flush the full style. The textimage store must be deleted.
+    $style->flush();
+    $this->assertDirectoryDoesNotExist($directory);
+  }
+
 }


### PR DESCRIPTION
Ports [mediabounds' fix](https://www.drupal.org/i/3518018) to 5.0.x: core passes a path to hook_image_style_flush() when a single file entity is deleted, and Textimage was wiping its whole style cache on every file deletion. The hook now only flushes when the path is NULL, and a kernel regression test covers both flush modes.