### PR TITLE
fix(#3425393): no crash when formatter has no image style

### DIFF
--- a/src/Plugin/Field/FieldFormatter/TextimageImageFieldFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TextimageImageFieldFormatter.php
@@ -20,6 +20,7 @@ use Drupal\image\ImageDerivativeUtilities;
 use Drupal\image\ImageStyleStorageInterface;
 use Drupal\image\Plugin\Field\FieldFormatter\ImageFormatter;
 use Drupal\textimage\TextimageFactoryInterface;
+use Drupal\textimage\TextimageLogger;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -61,6 +62,8 @@ class TextimageImageFieldFormatter extends ImageFormatter {
    *   The file URL generator service.
    * @param \Drupal\image\ImageDerivativeUtilities|null $imageDerivativeUtilities
    *   The ImageDerivativeUtilities service.
+   * @param \Drupal\textimage\TextimageLogger $logger
+   *   A logger instance.
    */
   public function __construct(
     string $plugin_id,
@@ -76,6 +79,7 @@ class TextimageImageFieldFormatter extends ImageFormatter {
     FileUrlGeneratorInterface $fileUrlGenerator,
     // @todo remove nullability once drupal:11.4.0 is minimum.
     ?ImageDerivativeUtilities $imageDerivativeUtilities,
+    protected readonly TextimageLogger $logger,
   ) {
     parent::__construct(
       $plugin_id,
@@ -110,6 +114,7 @@ class TextimageImageFieldFormatter extends ImageFormatter {
       $container->get(FileUrlGeneratorInterface::class),
       // @todo remove the class existence check once drupal:11.4.0 is minimum.
       class_exists(ImageDerivativeUtilities::class) ? $container->get(ImageDerivativeUtilities::class) : NULL,
+      $container->get(TextimageLogger::class),
     );
   }
 
@@ -245,8 +250,16 @@ class TextimageImageFieldFormatter extends ImageFormatter {
     }
 
     // Get image style.
-    /** @var \Drupal\image\ImageStyleInterface $image_style */
     $image_style = $this->imageStyleStorage->load($this->getSetting('image_style'));
+
+    // Do not render when the image style is missing. This happens when the
+    // formatter is saved without a style, or the style was deleted.
+    if ($image_style === NULL) {
+      $this->logger->warning('Textimage cannot render %field. The image style is missing. Select a valid image style in the display settings.', [
+        '%field' => $items->getFieldDefinition()->getLabel(),
+      ]);
+      return [];
+    }
 
     // Collect bubbleable metadata.
     $bubbleable_metadata = new BubbleableMetadata();

--- a/src/Plugin/Field/FieldFormatter/TextimageTextFieldFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/TextimageTextFieldFormatter.php
@@ -252,6 +252,15 @@ class TextimageTextFieldFormatter extends FormatterBase implements ContainerFact
     // Get image style.
     $image_style = $this->imageStyleStorage->load($this->getSetting('image_style'));
 
+    // Do not render when the image style is missing. This happens when the
+    // formatter is saved without a style, or the style was deleted.
+    if ($image_style === NULL) {
+      $this->logger->warning('Textimage cannot render %field. The image style is missing. Select a valid image style in the display settings.', [
+        '%field' => $items->getFieldDefinition()->getLabel(),
+      ]);
+      return [];
+    }
+
     // Collect bubbleable metadata.
     $bubbleable_metadata = new BubbleableMetadata();
 

--- a/src/Textimage.php
+++ b/src/Textimage.php
@@ -152,12 +152,15 @@ class Textimage implements TextimageInterface {
   /**
    * {@inheritdoc}
    */
-  public function setStyle(ImageStyleInterface $image_style): static {
+  public function setStyle(?ImageStyleInterface $image_style): static {
     if ($this->style) {
       throw new TextimageException("Image style already set");
     }
+    if (!$image_style instanceof ImageStyleInterface) {
+      throw new \InvalidArgumentException('Invalid image style provided.');
+    }
     $this->set('style', $image_style);
-    $effects = @$this->style->getEffects()->getConfiguration();
+    $effects = $this->style->getEffects()->getConfiguration();
     $this->setEffects($effects);
     return $this;
   }

--- a/tests/src/Functional/TextimageFieldFormatterTest.php
+++ b/tests/src/Functional/TextimageFieldFormatterTest.php
@@ -155,6 +155,37 @@ class TextimageFieldFormatterTest extends TextimageTestBase {
   }
 
   /**
+   * Test the image formatter when no image style is selected.
+   *
+   * The node view must not crash when the formatter has no image style.
+   *
+   * @see https://www.drupal.org/i/3425393
+   */
+  public function testTextimageImageFieldFormatterMissingStyle(): void {
+    // Create an image field for testing.
+    $field_name = strtolower($this->randomMachineName());
+    $this->createImageField($field_name, 'node', 'article', [], ['alt_field' => 1]);
+
+    // Create a new node with an image.
+    $field_value = $this->getTestFiles('image', 39325)[0];
+    $nid = $this->createTextimageNode('image', $field_name, $field_value, 'article', 'Missing image style test');
+
+    // Set the formatter without an image style.
+    $display = $this->entityDisplayRepository->getViewDisplay('node', 'article', 'default');
+    $display->setComponent($field_name, [
+      'type' => 'textimage_image_field_formatter',
+      'settings' => [
+        'image_style' => '',
+      ],
+    ])->save();
+
+    // The node page must render without an error.
+    $this->drupalGet('node/' . $nid);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Missing image style test');
+  }
+
+  /**
    * Test Textimage formatter on multi-value text fields.
    */
   public function testTextimageMultiValueTextFieldFormatter(): void {

--- a/tests/src/Functional/TextimageFieldFormatterTest.php
+++ b/tests/src/Functional/TextimageFieldFormatterTest.php
@@ -125,6 +125,36 @@ class TextimageFieldFormatterTest extends TextimageTestBase {
   }
 
   /**
+   * Test the formatter when no image style is selected.
+   *
+   * The node view must not crash when the formatter has no image style.
+   *
+   * @see https://www.drupal.org/i/3425393
+   */
+  public function testTextimageTextFieldFormatterMissingStyle(): void {
+    // Create a text field for Textimage test.
+    $field_name = strtolower($this->randomMachineName());
+    $this->createTextField($field_name, 'article');
+
+    // Create a new node.
+    $nid = $this->createTextimageNode('text', $field_name, 'Missing style test', 'article', 'Missing style test');
+
+    // Set the formatter without an image style.
+    $display = $this->entityDisplayRepository->getViewDisplay('node', 'article', 'default');
+    $display->setComponent($field_name, [
+      'type' => 'textimage_text_field_formatter',
+      'settings' => [
+        'image_style' => '',
+      ],
+    ])->save();
+
+    // The node page must render without an error.
+    $this->drupalGet('node/' . $nid);
+    $this->assertSession()->statusCodeEquals(200);
+    $this->assertSession()->pageTextContains('Missing style test');
+  }
+
+  /**
    * Test Textimage formatter on multi-value text fields.
    */
   public function testTextimageMultiValueTextFieldFormatter(): void {


### PR DESCRIPTION
Builds on [abhishek_gupta1's patch](https://www.drupal.org/i/3425393): setStyle() now rejects a null style explicitly, and both field formatters skip rendering with a logged warning when the configured image style is missing or was deleted, instead of throwing a TypeError on node view. A functional regression test renders a node with a style-less formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented formatter errors when a configured image style is unavailable.
  - Added clear warning logging and safely skips rendering affected elements.
  - Improved handling of missing or invalid image styles during textimage processing.

- **Tests**
  - Added functional coverage confirming text content still renders successfully when no image style is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->